### PR TITLE
[fix]通知設定の不具合を修正

### DIFF
--- a/back/app/controllers/api/v1/cosmetic_usages_controller.rb
+++ b/back/app/controllers/api/v1/cosmetic_usages_controller.rb
@@ -4,6 +4,11 @@ module Api
       before_action :set_current_user
 
       def create
+        if cosmetic_usage_params.values.all?(&:blank?)
+          render json: { message: '新規作成をスキップしました。' }, status: :ok
+          return
+        end
+
         existing_cosmetic_usage = @current_user.cosmetic_usages.find_by(
           item_type: cosmetic_usage_params[:item_type],
           open_date: cosmetic_usage_params[:open_date],
@@ -11,7 +16,7 @@ module Api
         )
 
         if existing_cosmetic_usage
-          render json: { error: '同じ使用期限設定が既に存在します。' }, status: :unprocessable_entity
+          render json: { message: '同じ使用期限設定が既に存在します。' }, status: :ok
           return
         end
 

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::API
   private
 
   def set_current_user
-    Rails.logger.info "Current session: #{session.inspect}"  # セッション情報をログに出力
+    Rails.logger.info "Current session: #{session.inspect}"
 
     if request.headers["Authorization"].present?
       received_access_token = request.headers["Authorization"].split(' ').last
@@ -22,10 +22,8 @@ class ApplicationController < ActionController::API
     end
 
     if session[:user_id] && session[:access_token] == received_access_token
-      # セッションからユーザー情報を取得
       @current_user = User.find_by(id: session[:user_id])
     else
-      # LINE APIからユーザー情報を取得
       session.delete(:access_token)
       user_info = fetch_user_info_from_line(received_access_token)
 
@@ -35,19 +33,15 @@ class ApplicationController < ActionController::API
         return
       end
 
-      # LINEのuserIdをもとにユーザー検索
       @current_user = User.find_or_initialize_by(uid: user_info['userId'], provider: 'line')
 
-      # ユーザー情報を更新
       @current_user.name = user_info['displayName'] if user_info['displayName']
       @current_user.avatar = user_info['pictureUrl'] if user_info['pictureUrl']
 
       if @current_user.save
-        # セッションにユーザー情報を保存
         session[:user_id] = @current_user.id
         session[:access_token] = received_access_token
       else
-        # ユーザー情報の保存に失敗した場合のエラーメッセージをログに出力
         Rails.logger.error "Failed to save user: #{@current_user.errors.full_messages.join(', ')}"
         render json: { error: 'Failed to save user info' }, status: :internal_server_error
         return
@@ -55,7 +49,6 @@ class ApplicationController < ActionController::API
     end
   end
 
-  # LINEのユーザー情報を取得
   def fetch_user_info_from_line(access_token)
     uri = URI.parse("https://api.line.me/v2/profile")
     request = Net::HTTP::Get.new(uri)
@@ -67,11 +60,15 @@ class ApplicationController < ActionController::API
 
     if response.code != "200"
       Rails.logger.error "LINE API Error: #{response.body}"
-      render json: { error: 'Failed to fetch user info from LINE', details: response.body }, status: :internal_server_error
-      return
+      error_response = JSON.parse(response.body)
+      if error_response["message"] == "invalid token"
+        render json: { error: 'Invalid token. Please re-authenticate.' }, status: :unauthorized
+      else
+        render json: { error: 'Failed to fetch user info from LINE', details: response.body }, status: :internal_server_error
+      end
+      return nil
     end
 
-    Rails.logger.info "LINE API Response: #{response.body}"
     JSON.parse(response.body)
   end
 end

--- a/front/app/reviews/[id]/page.tsx
+++ b/front/app/reviews/[id]/page.tsx
@@ -164,7 +164,8 @@ export default function ReviewDetails() {
     const fetchData = async () => {
       try {
         const [reviewsResponse, favoriteCosmetics] = await Promise.all([
-          axios.get<ApiResponse[]>(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/reviews`, { headers: token ? { Authorization: `Bearer ${token}` } : {} }),
+          axios.get<ApiResponse[]>(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/reviews`,
+            { headers: token ? { Authorization: `Bearer ${token}` } : {} }),
           fetchFavoriteCosmetics()
         ]);
 
@@ -224,6 +225,7 @@ export default function ReviewDetails() {
     try {
       await axios.delete(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/reviews/${reviewId}`, {
         headers: headers,
+        withCredentials: true,
       });
       setReviews(reviews.filter(review => review.id !== reviewId));
       toast.success('レビューを削除しました');
@@ -252,6 +254,7 @@ export default function ReviewDetails() {
 
       await axios.put(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/reviews/${editingReview.id}`, updatedReviewData, {
         headers: headers,
+        withCredentials: true,
       });
 
       const updatedReviews = reviews.map((review) => review.id === editingReview.id ? { ...review, ...updatedReviewData.review } : review);
@@ -301,8 +304,8 @@ export default function ReviewDetails() {
         <div className='flex flex-col items-center p-10'>
           {productReviews.map((productReview) => (
             <div key={productReview.id} className="w-full max-w-4xl">
-              <div className="relative h-[150px]">
-                <Image src={productReview.image_url} alt="" layout="fill" objectFit="contain" quality={100} />
+              <div className="flex items-center justify-center h-[150px] mt-4">
+                <Image src={productReview.image_url} alt="Image" width={128} height={128} objectFit="contain" quality={100} />
               </div>
               <h2 className="text-lg">{truncateName(productReview.reviews[0]?.title ?? 'タイトル不明')}</h2>
               <p>{productReview.price}円</p>

--- a/front/app/reviews/page.tsx
+++ b/front/app/reviews/page.tsx
@@ -8,7 +8,7 @@ import ReviewSearchForm from '../components/search/ReviewSearchForm';
 import ReviewSearchResult from '../components/search/ReviewSearchResult';
 import CustomButton from '@/components/ui/custom-button';
 import {
-  AlertTriangle,
+  Search,
   AlertCircle,
   X
 } from "lucide-react"
@@ -173,10 +173,10 @@ export default function Reviews() {
                 </div>
               </div>
               <div className="flex items-start mb-2">
-                <AlertTriangle className="mr-1 h-5 w-5" />
-                <p className='marked-text'>注意事項</p>
+                <Search className="mr-1 h-5 w-5" />
+                <p className='marked-text'>レビューを検索してみよう！</p>
               </div>
-              <p>レビュー投稿に付けられたタグで商品を検索できます。検索結果が表示されない場合、該当のレビュー投稿がない可能性があります。条件を変更して検索してみてください。</p>
+              <p>レビューに付けられたタグで皆さんのレビューを検索できます。検索結果が表示されない場合、該当のレビューがない可能性があります。条件を変更して検索してみてください。</p>
             </div>
           </div>
           <div className='flex flex-col items-center space-y-4 p-10'>
@@ -186,8 +186,8 @@ export default function Reviews() {
               {productReviews.map((productReview) => (
                 <div key={productReview.id} className="shadow-md rounded-md overflow-hidden cursor-pointer max-w-sm mx-auto">
                   {productReview.image_url && (
-                    <div className="relative h-[150px] mt-4">
-                      <Image src={productReview.image_url} alt="" layout="fill" objectFit="contain" quality={100} />
+                    <div className="flex items-center justify-center h-[150px] mt-4">
+                      <Image src={productReview.image_url} alt="Image" width={128} height={128} objectFit="contain" quality={100} />
                     </div>
                   )}
                   <div className="p-4 text-center">


### PR DESCRIPTION
## 概要
- 通知設定の不具合を修正
  - 一度通知設定後、別の通知設定を追加して更新すると、既存の設定が別のIDで保存されてしまう
  - 何も入力せずに更新すると422（Unprocessable Entity）が発生してしまう
    - バックエンド側で以下の処理を実装
      - 既に同じ設定が存在する場合は保存せずに200を返す
      - すべてのパラメータ（製品タイプ、開封日、使用期限）が空の場合、新規作成をスルーし200を返す

- ApplicationControllerにエラーハンドリングを追加