### PR TITLE
[fix]レビュー一覧ページの修正

### DIFF
--- a/back/app/controllers/api/v1/reviews_controller.rb
+++ b/back/app/controllers/api/v1/reviews_controller.rb
@@ -5,8 +5,8 @@ module Api
       before_action :set_review, only: [:show, :update, :destroy]
 
       def index
-        @reviews = Review.where(visibility: true)
-        render json: @reviews, include: [:user]
+        @reviews = Review.where(visibility: true).includes(:favorite_cosmetic)
+        render json: @reviews, include: [:user, :favorite_cosmetic]
       end
 
       def show

--- a/front/app/components/search/RecommendedCosmetics.tsx
+++ b/front/app/components/search/RecommendedCosmetics.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import CustomButton from '@/components/ui/custom-button';
 import { FavoriteIconAnim } from '@/components/ui/FavoriteIconAnim';
 import { SyncLoader } from 'react-spinners';
-import { RecommendedCosmeticsProps } from '../../types'
+import { RecommendedCosmeticsProps } from '../../types';
 import { Cosmetic } from './search.type';
 
 const RecommendedCosmetics: React.FC<RecommendedCosmeticsProps> = ({ searchParams }) => {

--- a/front/app/reviews/page.tsx
+++ b/front/app/reviews/page.tsx
@@ -55,31 +55,31 @@ export default function Reviews() {
 
   useEffect(() => {
     const fetchAndCombineReviews = async () => {
-      const favoriteCosmetics = await fetchFavoriteCosmetics();
       const reviewsResponse = await axios.get(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/reviews`, {
         headers: headers,
         withCredentials: true,
       });
       const reviews: Review[] = reviewsResponse.data;
 
-      const productReviewsMap: { [key: number]: ProductReviews } = {};
+      const productReviewsMap: { [key: string]: ProductReviews } = {};
       reviews.forEach(review => {
-        const cosmetic = favoriteCosmetics.find(c => c.id === review.favorite_cosmetic_id);
+        if (review.favorite_cosmetic_id === undefined) return;
+        const cosmetic = review.favorite_cosmetic_id.toString();
         if (!cosmetic) return;
 
-        if (!productReviewsMap[cosmetic.id]) {
-          productReviewsMap[cosmetic.id] = {
-            id: cosmetic.id,
-            item_url: cosmetic.item_url,
-            image_url: cosmetic.image_url,
+        if (!productReviewsMap[cosmetic]) {
+          productReviewsMap[cosmetic] = {
+            id: parseInt(cosmetic),
+            item_url: cosmetic,
+            image_url: cosmetic,
             averageRating: 0,
             reviewCount: 0,
             reviews: [],
-            price: cosmetic.price,
+            price: parseInt(cosmetic),
           };
         }
 
-        productReviewsMap[cosmetic.id].reviews.push(review);
+        productReviewsMap[cosmetic].reviews.push(review);
       });
 
       const ratings = {

--- a/front/app/types/index.ts
+++ b/front/app/types/index.ts
@@ -1,5 +1,3 @@
-import { Dispatch, SetStateAction } from 'react';
-
 export interface Session {
   accessToken?: string;
   user?: {


### PR DESCRIPTION
## 概要
- レビュー一覧ページの修正
  - レビュー一覧ページに自分のレビュー投稿しか表示されない
  - `fetchFavoriteCosmetics`関数で、自分のレビュー投稿しか返さないようになっているのが原因？
  - バックエンド側で`favorite_cosmetics`テーブルの全情報をあらかじめ`reviews`テーブルに結合しておき、フロントエンドから一度のリクエストでレビューとお気に入りコスメの情報を取得できるように実装