### PR TITLE
[update]レビュー一覧ページの改良

### DIFF
--- a/front/app/reviews/page.tsx
+++ b/front/app/reviews/page.tsx
@@ -135,28 +135,31 @@ export default function Reviews() {
             <ReviewSearch onSearch={handleSearch} />
             <div className='grid grid-cols-1 md:grid-cols-3 gap-4 w-full'>
               {productReviews.map((productReview) => (
-                productReview.reviews.map((review) => (
-                  <div key={productReview.item_code} className="shadow-md rounded-md overflow-hidden max-w-sm mx-auto">
-                    {productReview.image_url && (
-                      <div className="flex items-center justify-center h-[150px] mt-4">
-                        <Image src={productReview.image_url || '/image.png'} alt="Image" width={128} height={128} objectFit="contain" quality={100} />
-                      </div>
-                    )}
-                    <div className="p-4 text-center">
-                      <h3 className="text-lg">{truncateName(productReview.reviews[0].title)}</h3>
-                      <p>{`★ ${productReview.averageRating.toFixed(1)} (${productReview.reviewCount}件)`}</p>
-                      <p>{productReview.price}円</p>
-                      <div className="flex justify-center mt-2">
-                        <CustomButton
-                          colorClass="hover:bg-E0DBD2 hover:text-text-color"
-                          onClick={() => router.push(`/reviews/${review.id}`)}
-                        >
-                          レビュー詳細へ
-                        </CustomButton>
-                      </div>
+                <div key={productReview.item_code} className="shadow-md rounded-md overflow-hidden max-w-sm mx-auto">
+                  {productReview.image_url && (
+                    <div className="flex items-center justify-center h-[150px] mt-4">
+                      <Image src={productReview.image_url || '/image.png'} alt="Image" width={128} height={128} objectFit="contain" quality={100} />
+                    </div>
+                  )}
+                  <div className="p-4 text-center">
+                    <h3 className="text-lg">{truncateName(productReview.reviews[0].title)}</h3>
+                    <p>{`★ ${productReview.averageRating.toFixed(1)} (${productReview.reviewCount}件)`}</p>
+                    <p>{productReview.price}円</p>
+                    <ul>
+                      {productReview.reviews.map((review) => (
+                        <li key={review.id}>{review.body}</li>
+                      ))}
+                    </ul>
+                    <div className="flex justify-center mt-2">
+                      <CustomButton
+                        colorClass="hover:bg-E0DBD2 hover:text-text-color"
+                        onClick={() => router.push(`/reviews/${productReview.item_code}`)}
+                      >
+                        レビュー詳細へ
+                      </CustomButton>
                     </div>
                   </div>
-                ))
+                </div>
               ))}
             </div>
           </div>


### PR DESCRIPTION
## 概要
- レビュー一覧ページの改良
  - 同じ商品に対するレビューを1つにまとめて表示
  - 詳細ページのURLを`item_code`に基づいて設定