### PR TITLE
[add]RSpecに必要なGemのインストール

### DIFF
--- a/back/.rspec
+++ b/back/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -54,9 +54,12 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'capybara'
+  gem 'simplecov'
 end
 
 group :development do

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -71,11 +71,22 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     case_transform (0.2)
       activesupport
     concurrent-ruby (1.2.2)
@@ -86,6 +97,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -93,6 +105,11 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
+    factory_bot (6.4.6)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     fugit (1.9.0)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
@@ -116,6 +133,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
@@ -143,6 +161,7 @@ GEM
     pg (1.5.4)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.4)
     puma (5.6.7)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -247,6 +266,12 @@ GEM
       fugit (~> 1.8)
       globalid (>= 1.0.1)
       sidekiq (>= 6)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     stringio (3.1.0)
     thor (1.3.0)
     timeout (0.4.1)
@@ -256,6 +281,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -267,8 +294,10 @@ DEPENDENCIES
   active_model_serializers
   bootsnap
   byebug
+  capybara
   debug
   dotenv-rails
+  factory_bot_rails
   json
   pg (~> 1.1)
   puma (~> 5.0)
@@ -282,6 +311,7 @@ DEPENDENCIES
   rubocop-rspec
   sidekiq
   sidekiq-cron
+  simplecov
   tzinfo-data
 
 RUBY VERSION

--- a/back/spec/auth_module.rb
+++ b/back/spec/auth_module.rb
@@ -1,0 +1,5 @@
+module AuthModule
+  def generate_token_for_user(user)
+    JWT.encode({ user_id: user.uid }, ENV.fetch('LINE_CHANNEL_SECRET', nil))
+  end
+end

--- a/back/spec/rails_helper.rb
+++ b/back/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,6 +24,7 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -62,4 +64,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
+  config.include AuthModule
 end

--- a/front/app/column/page.tsx
+++ b/front/app/column/page.tsx
@@ -1,4 +1,3 @@
-'use client';
 import React from 'react';
 import {
   Accordion,

--- a/front/app/privacy_policy/page.tsx
+++ b/front/app/privacy_policy/page.tsx
@@ -1,4 +1,3 @@
-'use client';
 import React from 'react';
 
 export default function PrivacyPolicy() {

--- a/front/app/term_of_service/page.tsx
+++ b/front/app/term_of_service/page.tsx
@@ -1,4 +1,3 @@
-'use client';
 import React from 'react';
 
 export default function TermOfService() {


### PR DESCRIPTION
## 概要
- RSpecに必要なGemのインストール
  - `factory_bot_rails`、`capybara`、`simplecov`
- `auth_module.rb`の作成